### PR TITLE
docs: rename PYPI to Index in links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,6 @@ always_document_param_types = True
 sphinx_deployment_dll = {
     "Links": {
         "Repository": "https://github.com/msclock/sphinx-deployment/",
-        "PYPI": "https://pypi.org/project/sphinx-deployment/",
+        "Index": "https://pypi.org/project/sphinx-deployment/",
     }
 }


### PR DESCRIPTION
closes #20 